### PR TITLE
Add an example CLI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+test --test_output=errors

--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
 WORKSPACE_ROOT=$(git rev-parse --show-toplevel)
 
 export PATH="${WORKSPACE_ROOT}/tools:$PATH"
+export GO111MODULE=on

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("//rules:shellcheck.bzl", "shellcheck", "shellcheck_test")
 
-# gazelle:prefix github.com/aignas/code
+# gazelle:build_file_name BUILD.bazel
 gazelle(name = "gazelle")
 
 buildifier(name = "buildifier")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,7 +24,7 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 gazelle_dependencies()
 
@@ -52,4 +52,46 @@ exports_files(["shellcheck"])
     sha256 = "64f17152d96d7ec261ad3086ed42d18232fcb65148b44571b564d688269d36c8",
     strip_prefix = "shellcheck-v0.7.1",
     urls = ["https://github.com/koalaman/shellcheck/releases/download/v0.7.1/shellcheck-v0.7.1.linux.x86_64.tar.xz"],
+)
+
+go_repository(
+    name = "com_github_davecgh_go_spew",
+    importpath = "github.com/davecgh/go-spew",
+    sum = "h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=",
+    version = "v1.1.0",
+)
+
+go_repository(
+    name = "com_github_pmezard_go_difflib",
+    importpath = "github.com/pmezard/go-difflib",
+    sum = "h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=",
+    version = "v1.0.0",
+)
+
+go_repository(
+    name = "com_github_stretchr_objx",
+    importpath = "github.com/stretchr/objx",
+    sum = "h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=",
+    version = "v0.1.0",
+)
+
+go_repository(
+    name = "com_github_stretchr_testify",
+    importpath = "github.com/stretchr/testify",
+    sum = "h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=",
+    version = "v1.4.0",
+)
+
+go_repository(
+    name = "in_gopkg_check_v1",
+    importpath = "gopkg.in/check.v1",
+    sum = "h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=",
+    version = "v0.0.0-20161208181325-20d25e280405",
+)
+
+go_repository(
+    name = "in_gopkg_yaml_v2",
+    importpath = "gopkg.in/yaml.v2",
+    sum = "h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=",
+    version = "v2.2.2",
 )

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:prefix github.com/aignas/c

--- a/src/cmd/cli/BUILD.bazel
+++ b/src/cmd/cli/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/aignas/c/cmd/cli",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "cli",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    embed = [":go_default_library"],
+    deps = ["@com_github_stretchr_testify//assert:go_default_library"],
+)

--- a/src/cmd/cli/main.go
+++ b/src/cmd/cli/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func main() {
+	os.Exit(run(os.Stdout, os.Args))
+}
+
+// run is the main entry point, which is testable. The out should be os.Stdout,
+// and in should be os.Args.
+func run(out io.Writer, in []string) int {
+	fmt.Fprintln(out, "Hello, world!")
+	fmt.Fprintln(out, "Got args:", strings.Join(in, ","))
+	return 0
+}

--- a/src/cmd/cli/main_test.go
+++ b/src/cmd/cli/main_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	var out bytes.Buffer
+
+	assert.Zero(t, run(&out, []string{"arg0", "arg1", "arg2"}))
+	assert.Equal(t, out.String(), `Hello, world!
+Got args: arg0,arg1,arg2
+`)
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,0 +1,5 @@
+module github.com/aignas/c
+
+go 1.14
+
+require github.com/stretchr/testify v1.4.0

--- a/src/go.sum
+++ b/src/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/tools/ci/ci-test.sh
+++ b/tools/ci/ci-test.sh
@@ -7,12 +7,12 @@ die() {
 }
 
 ensure() {
-    "$1"
+    "$@"
     files="$(git status --porcelain)"
     if [ -n "$files" ]; then
         echo "Detected changes to:"
         echo "$files"
-        die "Please run '$1' to cleanup the build files"
+        die "Please run '$*' to cleanup the build files"
     fi
 }
 
@@ -21,4 +21,6 @@ cd "${WORKSPACE_ROOT}"
 
 ensure tools/buildifier
 ensure tools/gazelle
+ensure tools/gazelle update-repos -from_file=src/go.mod -prune
 bazel test //:verify-all
+bazel test //src/...


### PR DESCRIPTION
Add an example go CLI in order to have a repository structure for coding Go applications.

Summary:
- Fix `gazelle` repository prefix.
- Improve the CI script to ensure that the repos are updated.
- Use go modules and enable them via `direnv`.
- Run `bazel test` on the `src` directory, which will contain `go` source code.
